### PR TITLE
Don't require ssh login to git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ to install the development version of GNU social.
 To get it, use the git version control tool
 <http://git-scm.com/> like so:
 
-    git clone git@git.gnu.io:gnu/gnu-social.git
+    git clone https://git.gnu.io/gnu/gnu-social.git
 
 In the current phase of development it is probably
 recommended to use git as a means to stay up to date


### PR DESCRIPTION
People who do not have an account on gnu.io cannot clone the project via ssh. This change to https allows interested users, such as myself, to clone code.